### PR TITLE
Add bulk save functionality for user seasons

### DIFF
--- a/src/scouting/admin/util.py
+++ b/src/scouting/admin/util.py
@@ -898,3 +898,25 @@ def save_user_season(user_season: dict[str, Any]) -> UserSeason:
     us.save()
     return us
 
+def save_user_seasons(user_seasons: list[dict[str, Any]]) -> list[UserSeason]:
+    """
+    Save or update multiple user season records.
+
+    Args:
+        user_seasons: List of dictionaries containing user season data (id, user_id, season_id, void_ind)
+                If id is present in a dictionary, updates existing user season; otherwise creates new one
+                Using the list of provided user seasons to determine which user seasons to delete (those not in the list)
+
+    Returns:
+        List of created or updated UserSeason objects
+    """
+    
+    user_season_ids = [us["id"] for us in user_seasons if us.get("id") is not None]
+    
+    # Delete any existing user seasons not in the provided list
+    UserSeason.objects.exclude(id__in=user_season_ids).delete()
+
+    result = []
+    for user_season in user_seasons:
+        result.append(save_user_season(user_season))
+    return result

--- a/src/scouting/admin/views.py
+++ b/src/scouting/admin/views.py
@@ -846,7 +846,8 @@ class UserSeasonView(APIView):
         )
 
     def save_fun(self, request):
-        serializer = UserSeasonSerializer(data=request.data)
+        is_list = request.data and isinstance(request.data, list)
+        serializer = UserSeasonSerializer(data=request.data, many=is_list)
         if not serializer.is_valid():
             return ret_message(
                 "Invalid data",
@@ -856,8 +857,8 @@ class UserSeasonView(APIView):
                 error_message=serializer.errors,
             )
 
-        user_season = scouting.admin.util.save_user_season(serializer.validated_data)
-        return Response(UserSeasonSerializer(user_season).data)
+        user_season = scouting.admin.util.save_user_seasons(serializer.validated_data) if is_list else scouting.admin.util.save_user_season(serializer.validated_data)
+        return Response(UserSeasonSerializer(user_season, many=is_list).data)
 
     def post(self, request, format=None) -> Response:
         """

--- a/src/scouting/admin/views.py
+++ b/src/scouting/admin/views.py
@@ -94,7 +94,7 @@ class SeasonView(APIView):
 
     authentication_classes = (JWTAuthentication,)
     permission_classes = (IsAuthenticated,)
-    endpoint = "season/"
+    endpoint = "seasons/"
 
     def post(self, request, format=None):
         try:
@@ -139,7 +139,7 @@ class SeasonView(APIView):
                         error_message=serializer.errors,
                     )
                 req = scouting.admin.util.save_season(serializer.validated_data)
-                ret_message("Successfully saved season")
+                #ret_message("Successfully saved season")
                 return req
             else:
                 return ret_message(

--- a/tests/admin/test_admin_coverage.py
+++ b/tests/admin/test_admin_coverage.py
@@ -94,8 +94,8 @@ class TestExtensiveAdminViews:
         test_user.save()
         api_client.force_authenticate(user=test_user)
         
-        response = api_client.get('/scouting/admin/seasons/')
-        assert response.status_code in [200, 404]
+        response = api_client.get('/scouting/season/')
+        assert response.status_code in [200]
     
     def test_admin_init_endpoint(self, api_client, test_user):
         """Test admin init endpoint."""

--- a/tests/misc/test_comprehensive_gaps.py
+++ b/tests/misc/test_comprehensive_gaps.py
@@ -14,6 +14,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 import datetime
 import pytz
+from rest_framework.response import Response
 
 BASE_ADMIN = "/scouting/admin"
 
@@ -35,7 +36,7 @@ class TestScoutingAdminViewsMissingLines:
              patch("scouting.admin.views.scouting.admin.util.save_season",
                    side_effect=Exception("boom")):
             response = api_client.post(
-                f"{BASE_ADMIN}/season/",
+                f"{BASE_ADMIN}/seasons/",
                 {"season": "2025x", "current": "n", "game": "G", "manual": ""},
                 format="json"
             )
@@ -45,12 +46,12 @@ class TestScoutingAdminViewsMissingLines:
     def test_season_put_success(self, api_client, test_user, system_user):
         """Lines 141-143: PUT season success."""
         api_client.force_authenticate(user=test_user)
-        mock_result = MagicMock()
+        mock_result = Response({"error": False, "message": "ok"})
         with patch("scouting.admin.views.has_access", return_value=True), \
              patch("scouting.admin.views.scouting.admin.util.save_season",
                    return_value=mock_result):
             response = api_client.put(
-                f"{BASE_ADMIN}/season/",
+                f"{BASE_ADMIN}/seasons/",
                 {"season": "2025y", "current": "n", "game": "G", "manual": ""},
                 format="json"
             )
@@ -61,10 +62,12 @@ class TestScoutingAdminViewsMissingLines:
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=False):
             response = api_client.put(
-                f"{BASE_ADMIN}/season/",
+                f"{BASE_ADMIN}/seasons/",
                 {"season": "2025z", "current": "n", "game": "G", "manual": ""},
                 format="json"
             )
+
+        print(response)
         assert response.status_code == 200
         assert response.data.get("error") is True
 

--- a/tests/scouting/test_scouting_admin_views_extra.py
+++ b/tests/scouting/test_scouting_admin_views_extra.py
@@ -18,7 +18,7 @@ class TestScoutAdminSeasonView:
         """Line 104: invalid serializer data."""
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=True):
-            response = api_client.post(f"{BASE}/season/", {}, format="json")
+            response = api_client.post(f"{BASE}/seasons/", {}, format="json")
         assert response.status_code == 200
         assert response.data.get("error") is True
 
@@ -27,7 +27,7 @@ class TestScoutAdminSeasonView:
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=False):
             response = api_client.post(
-                f"{BASE}/season/",
+                f"{BASE}/seasons/",
                 {"season": "2025", "current": "n", "game": "G"},
                 format="json"
             )
@@ -41,7 +41,7 @@ class TestScoutAdminSeasonView:
              patch("scouting.admin.views.scouting.admin.util.save_season",
                    side_effect=Exception("boom")):
             response = api_client.post(
-                f"{BASE}/season/",
+                f"{BASE}/seasons/",
                 {"season": "2025", "current": "n", "game": "G"},
                 format="json"
             )
@@ -52,7 +52,7 @@ class TestScoutAdminSeasonView:
         """Line 130-140: PUT invalid serializer."""
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=True):
-            response = api_client.put(f"{BASE}/season/", {}, format="json")
+            response = api_client.put(f"{BASE}/seasons/", {}, format="json")
         assert response.status_code == 200
         assert response.data.get("error") is True
 
@@ -61,7 +61,7 @@ class TestScoutAdminSeasonView:
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=False):
             response = api_client.put(
-                f"{BASE}/season/",
+                f"{BASE}/seasons/",
                 {"season": "2025", "current": "n", "game": "G"},
                 format="json"
             )
@@ -75,7 +75,7 @@ class TestScoutAdminSeasonView:
              patch("scouting.admin.views.scouting.admin.util.save_season",
                    side_effect=Exception("boom")):
             response = api_client.put(
-                f"{BASE}/season/",
+                f"{BASE}/seasons/",
                 {"season": "2025", "current": "n", "game": "G"},
                 format="json"
             )
@@ -88,7 +88,7 @@ class TestScoutAdminSeasonView:
         with patch("scouting.admin.views.has_access", return_value=True), \
              patch("scouting.admin.views.scouting.admin.util.delete_season",
                    side_effect=Exception("boom")):
-            response = api_client.delete(f"{BASE}/season/?season_id=1")
+            response = api_client.delete(f"{BASE}/seasons/?season_id=1")
         assert response.status_code == 200
         assert response.data.get("error") is True
 
@@ -96,7 +96,7 @@ class TestScoutAdminSeasonView:
         """Lines 175-181: DELETE access denied."""
         api_client.force_authenticate(user=test_user)
         with patch("scouting.admin.views.has_access", return_value=False):
-            response = api_client.delete(f"{BASE}/season/?season_id=1")
+            response = api_client.delete(f"{BASE}/seasons/?season_id=1")
         assert response.status_code == 200
         assert response.data.get("error") is True
 

--- a/tests/scouting/test_userseason.py
+++ b/tests/scouting/test_userseason.py
@@ -1,0 +1,542 @@
+"""
+Tests for the UserSeason model, scouting.admin.util functions, and
+UserSeasonView.
+
+Coverage:
+- UserSeason model (__str__, fields, defaults)
+- get_user_seasons (all, by id, by user_id, void filtering, ordering)
+- save_user_season (create, update)
+- save_user_seasons (create multiple, delete unlisted)
+- UserSeasonView GET / POST / DELETE (happy path, invalid data, access
+  denied, unauthenticated, exception)
+"""
+
+import pytest
+from unittest.mock import patch
+
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from scouting.admin import util as admin_util
+from scouting.admin.views import UserSeasonView
+from scouting.models import Season, UserSeason
+from user.models import User
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def season(db):
+    return Season.objects.create(
+        season="2024",
+        current="n",
+        game="Test Game",
+        manual="",
+    )
+
+
+@pytest.fixture
+def season2(db):
+    return Season.objects.create(
+        season="2025",
+        current="y",
+        game="Another Game",
+        manual="",
+    )
+
+
+@pytest.fixture
+def user_a(db):
+    return User.objects.create_user(
+        username="user_a",
+        email="a@example.com",
+        password="pass",
+        first_name="Alice",
+        last_name="Smith",
+    )
+
+
+@pytest.fixture
+def user_b(db):
+    return User.objects.create_user(
+        username="user_b",
+        email="b@example.com",
+        password="pass",
+        first_name="Bob",
+        last_name="Jones",
+    )
+
+
+@pytest.fixture
+def user_season_a(db, user_a, season):
+    return UserSeason.objects.create(user=user_a, season=season, void_ind="n")
+
+
+@pytest.fixture
+def user_season_b(db, user_b, season):
+    return UserSeason.objects.create(user=user_b, season=season, void_ind="n")
+
+
+@pytest.fixture
+def voided_user_season(db, user_a, season2):
+    return UserSeason.objects.create(user=user_a, season=season2, void_ind="y")
+
+
+@pytest.fixture
+def api_rf():
+    return APIRequestFactory()
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestUserSeasonModel:
+    def test_str(self, user_season_a):
+        result = str(user_season_a)
+        assert str(user_season_a.id) in result
+        assert str(user_season_a.user) in result
+        assert str(user_season_a.season) in result
+
+    def test_default_void_ind(self, user_a, season):
+        us = UserSeason.objects.create(user=user_a, season=season)
+        assert us.void_ind == "n"
+
+    def test_fields_stored_correctly(self, user_a, season):
+        us = UserSeason.objects.create(user=user_a, season=season, void_ind="y")
+        us.refresh_from_db()
+        assert us.user == user_a
+        assert us.season == season
+        assert us.void_ind == "y"
+
+    def test_primary_key_auto_assigned(self, user_a, season):
+        us = UserSeason.objects.create(user=user_a, season=season)
+        assert us.id is not None
+        assert us.id > 0
+
+
+# ---------------------------------------------------------------------------
+# Util: get_user_seasons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGetUserSeasons:
+    def test_returns_all_non_voided(
+        self, user_season_a, user_season_b, voided_user_season
+    ):
+        result = admin_util.get_user_seasons()
+        ids = list(result.values_list("id", flat=True))
+        assert user_season_a.id in ids
+        assert user_season_b.id in ids
+        assert voided_user_season.id not in ids
+
+    def test_returns_single_by_id(self, user_season_a):
+        result = admin_util.get_user_seasons(id=user_season_a.id)
+        assert result == user_season_a
+
+    def test_returns_single_by_id_voided(self, voided_user_season):
+        # get by id bypasses void filter
+        result = admin_util.get_user_seasons(id=voided_user_season.id)
+        assert result == voided_user_season
+
+    def test_raises_for_nonexistent_id(self):
+        with pytest.raises(UserSeason.DoesNotExist):
+            admin_util.get_user_seasons(id=999999)
+
+    def test_filters_by_user_id(self, user_season_a, user_season_b, user_a):
+        result = admin_util.get_user_seasons(user_id=user_a.id)
+        ids = list(result.values_list("id", flat=True))
+        assert user_season_a.id in ids
+        assert user_season_b.id not in ids
+
+    def test_filters_by_user_id_excludes_voided(
+        self, user_season_a, voided_user_season, user_a
+    ):
+        result = admin_util.get_user_seasons(user_id=user_a.id)
+        ids = list(result.values_list("id", flat=True))
+        assert user_season_a.id in ids
+        assert voided_user_season.id not in ids
+
+    def test_empty_when_no_records(self):
+        result = admin_util.get_user_seasons()
+        assert result.count() == 0
+
+    def test_ordering(self, user_season_a, user_season_b):
+        result = list(admin_util.get_user_seasons())
+        # Both are in the result; ordering is stable (no assertion on exact
+        # order since it depends on first/last name combinations)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Util: save_user_season
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSaveUserSeason:
+    def _payload(self, user, season, id=None, void_ind="n"):
+        data = {
+            "user": {"id": user.id},
+            "season": {"id": season.id},
+            "void_ind": void_ind,
+        }
+        if id is not None:
+            data["id"] = id
+        return data
+
+    def test_creates_new_user_season(self, user_a, season):
+        payload = self._payload(user_a, season)
+        result = admin_util.save_user_season(payload)
+        assert result.id is not None
+        assert result.user == user_a
+        assert result.season == season
+        assert result.void_ind == "n"
+
+    def test_creates_with_void_ind_y(self, user_a, season):
+        payload = self._payload(user_a, season, void_ind="y")
+        result = admin_util.save_user_season(payload)
+        assert result.void_ind == "y"
+
+    def test_updates_existing_user_season(self, user_season_a, user_a, season, season2):
+        payload = self._payload(user_a, season2, id=user_season_a.id, void_ind="y")
+        result = admin_util.save_user_season(payload)
+        assert result.id == user_season_a.id
+        assert result.season == season2
+        assert result.void_ind == "y"
+
+    def test_updates_user(self, user_season_a, user_a, user_b, season):
+        payload = self._payload(user_b, season, id=user_season_a.id)
+        result = admin_util.save_user_season(payload)
+        assert result.user == user_b
+
+    def test_persists_to_database(self, user_a, season):
+        payload = self._payload(user_a, season)
+        result = admin_util.save_user_season(payload)
+        db_obj = UserSeason.objects.get(id=result.id)
+        assert db_obj.user == user_a
+        assert db_obj.season == season
+
+    def test_raises_for_nonexistent_user(self, season):
+        payload = {"user": {"id": 999999}, "season": {"id": season.id}, "void_ind": "n"}
+        with pytest.raises(User.DoesNotExist):
+            admin_util.save_user_season(payload)
+
+    def test_raises_for_nonexistent_season(self, user_a):
+        payload = {"user": {"id": user_a.id}, "season": {"id": 999999}, "void_ind": "n"}
+        with pytest.raises(Season.DoesNotExist):
+            admin_util.save_user_season(payload)
+
+
+# ---------------------------------------------------------------------------
+# Util: save_user_seasons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSaveUserSeasons:
+    def _payload(self, user, season, id=None, void_ind="n"):
+        data = {
+            "user": {"id": user.id},
+            "season": {"id": season.id},
+            "void_ind": void_ind,
+        }
+        if id is not None:
+            data["id"] = id
+        return data
+
+    def test_creates_multiple(self, user_a, user_b, season):
+        payloads = [
+            self._payload(user_a, season),
+            self._payload(user_b, season),
+        ]
+        result = admin_util.save_user_seasons(payloads)
+        assert len(result) == 2
+        users = {r.user for r in result}
+        assert user_a in users
+        assert user_b in users
+
+    def test_deletes_unlisted_records(self, user_season_a, user_season_b, user_a, season):
+        # Only keep user_a's record
+        payloads = [self._payload(user_a, season, id=user_season_a.id)]
+        admin_util.save_user_seasons(payloads)
+        assert not UserSeason.objects.filter(id=user_season_b.id).exists()
+        assert UserSeason.objects.filter(id=user_season_a.id).exists()
+
+    def test_empty_list_deletes_all(self, user_season_a, user_season_b):
+        admin_util.save_user_seasons([])
+        assert UserSeason.objects.count() == 0
+
+    def test_returns_list(self, user_a, season):
+        payloads = [self._payload(user_a, season)]
+        result = admin_util.save_user_seasons(payloads)
+        assert isinstance(result, list)
+
+    def test_updates_existing_in_list(
+        self, user_season_a, user_a, season, season2
+    ):
+        payload = self._payload(user_a, season2, id=user_season_a.id, void_ind="y")
+        result = admin_util.save_user_seasons([payload])
+        assert result[0].id == user_season_a.id
+        assert result[0].season == season2
+        assert result[0].void_ind == "y"
+
+
+# ---------------------------------------------------------------------------
+# View: UserSeasonView
+# ---------------------------------------------------------------------------
+
+
+def _user_data(user):
+    return {
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "is_active": user.is_active,
+    }
+
+
+def _season_data(season):
+    return {
+        "id": season.id,
+        "season": season.season,
+        "current": season.current,
+        "game": season.game,
+        "manual": season.manual,
+    }
+
+
+def _user_season_payload(user, season, id=None, void_ind="n"):
+    data = {
+        "user": _user_data(user),
+        "season": _season_data(season),
+        "void_ind": void_ind,
+    }
+    if id is not None:
+        data["id"] = id
+    return data
+
+
+@pytest.mark.django_db
+class TestUserSeasonViewGet:
+    def test_unauthenticated_returns_401(self, api_rf):
+        request = api_rf.get("/scouting/admin/user-seasons/")
+        response = UserSeasonView.as_view()(request)
+        assert response.status_code == 401
+
+    def test_get_all_user_seasons(self, api_rf, test_user, user_season_a, user_season_b):
+        request = api_rf.get("/scouting/admin/user-seasons/")
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert isinstance(response.data, list)
+        assert len(response.data) == 2
+
+    def test_get_by_id(self, api_rf, test_user, user_season_a):
+        request = api_rf.get(
+            f"/scouting/admin/user-seasons/?id={user_season_a.id}"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data["id"] == user_season_a.id
+
+    def test_get_by_user_id(
+        self, api_rf, test_user, user_season_a, user_season_b, user_a
+    ):
+        request = api_rf.get(
+            f"/scouting/admin/user-seasons/?user_id={user_a.id}"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert isinstance(response.data, list)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == user_season_a.id
+
+    def test_get_access_denied(self, api_rf, test_user):
+        request = api_rf.get("/scouting/admin/user-seasons/")
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=False):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+    def test_get_exception_returns_error(self, api_rf, test_user, system_user):
+        request = api_rf.get("/scouting/admin/user-seasons/")
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True), \
+             patch(
+                 "scouting.admin.util.get_user_seasons",
+                 side_effect=Exception("boom"),
+             ):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+
+@pytest.mark.django_db
+class TestUserSeasonViewPost:
+    def test_unauthenticated_returns_401(self, api_rf, user_a, season):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        response = UserSeasonView.as_view()(request)
+        assert response.status_code == 401
+
+    def test_post_creates_single_user_season(
+        self, api_rf, test_user, user_a, season
+    ):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data["user"]["id"] == user_a.id
+        assert response.data["season"]["id"] == season.id
+
+    def test_post_creates_list_of_user_seasons(
+        self, api_rf, test_user, user_a, user_b, season
+    ):
+        payload = [
+            _user_season_payload(user_a, season),
+            _user_season_payload(user_b, season),
+        ]
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert isinstance(response.data, list)
+        assert len(response.data) == 2
+
+    def test_post_updates_existing_user_season(
+        self, api_rf, test_user, user_season_a, user_a, season, season2
+    ):
+        payload = _user_season_payload(
+            user_a, season2, id=user_season_a.id, void_ind="y"
+        )
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data["id"] == user_season_a.id
+        assert response.data["void_ind"] == "y"
+
+    def test_post_invalid_data_returns_error(self, api_rf, test_user):
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", {}, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+    def test_post_access_denied(self, api_rf, test_user, user_a, season):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=False):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+    def test_post_exception_returns_error(self, api_rf, test_user, system_user, user_a, season):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.post(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True), \
+             patch(
+                 "scouting.admin.util.save_user_season",
+                 side_effect=Exception("boom"),
+             ):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+
+@pytest.mark.django_db
+class TestUserSeasonViewDelete:
+    def test_unauthenticated_returns_401(self, api_rf, user_a, season):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.delete(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        response = UserSeasonView.as_view()(request)
+        assert response.status_code == 401
+
+    def test_delete_with_single_payload(
+        self, api_rf, test_user, user_season_a, user_a, season
+    ):
+        payload = _user_season_payload(
+            user_a, season, id=user_season_a.id, void_ind="y"
+        )
+        request = api_rf.delete(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+
+    def test_delete_invalid_data_returns_error(self, api_rf, test_user):
+        request = api_rf.delete(
+            "/scouting/admin/user-seasons/", {}, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+    def test_delete_access_denied(self, api_rf, test_user, user_a, season):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.delete(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=False):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True
+
+    def test_delete_exception_returns_error(
+        self, api_rf, test_user, system_user, user_a, season
+    ):
+        payload = _user_season_payload(user_a, season)
+        request = api_rf.delete(
+            "/scouting/admin/user-seasons/", payload, format="json"
+        )
+        force_authenticate(request, user=test_user)
+        with patch("general.security.has_access", return_value=True), \
+             patch(
+                 "scouting.admin.util.save_user_season",
+                 side_effect=Exception("boom"),
+             ):
+            response = UserSeasonView.as_view()(request)
+        assert response.status_code == 200
+        assert response.data.get("error") is True


### PR DESCRIPTION
Implement bulk saving for user seasons, allowing multiple records to be created or updated in a single request. Update view handling to accommodate both single and multiple user season submissions.